### PR TITLE
Let omnibus pick number of workers, except in a Solaris zone. Also enforces UTF8 encoding.

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -39,7 +39,15 @@ s3_bucket      'opscode-omnibus-cache'
 # ------------------------------
 build_retries 0
 fetcher_read_timeout 120
-workers 10
+
+# Work around for solaris zones, provide a less-bad number of workers
+if solaris? && Ohai['cpu']['total'] == 0
+  workers 10
+end
+
+# Some platforms do not have a UTF-8 locale, so we need to enforce one
+# or else the cacert chain will break among other things
+Encoding.default_external = Encoding::UTF_8
 
 # Load additional software
 # ------------------------------


### PR DESCRIPTION
When running in a Solaris zone with Ohai 8, the total number of
CPUs reported is 0. Instead of overriding the number of workers
globally, restrict it to just Solaris and a total CPU count of 0.

Also enables UTF8 encoding on all platforms, because some
default to C and this breaks many things.
