### PR TITLE
Bump Git version to 2.6.2

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -26,7 +26,7 @@ build_iteration 1
 
 override :ruby, version: "2.1.5"
 override :zlib, version: "1.2.8"
-override :git,  version: "1.9.0"
+override :git,  version: "2.6.2"
 override :cacerts, version: '2014.08.20'
 
 # creates required build directories


### PR DESCRIPTION
This matches what we currently deploy on non-toolchain platforms via the Omnibus cookbook:
https://github.com/chef-cookbooks/omnibus/blob/v3.1.3/attributes/default.rb#L24

/cc @chef/engineering-services 
