### PR TITLE
use ruby 2.1.8

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -25,7 +25,7 @@ install_dir    '/opt/omnibus-toolchain'
 build_version   '1.1.6'
 build_iteration 1
 
-override :ruby, version: "2.1.6"
+override :ruby, version: "2.1.8"
 override :git,  version: "2.7.3"
 
 # creates required build directories


### PR DESCRIPTION
This should fix licensing download errors on jenkins chef builders. On ruby 2.1.5 (the current ruby default version) the following code:
```
require 'open-uri'
open("https://www.openssl.org/source/license.html")
```
produces an error:
```
OpenSSL::SSL::SSLError: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A
```
Ruby 2.1.8 is able to successfully download the license.