### PR TITLE
Build and install berkshelf as part of the toolchain.

### DIFF
--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -34,6 +34,10 @@ dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 
+if linux? || mac_os_x?
+  dependency "berkshelf"
+end
+
 # For Solaris 10 and Freebsd 9 we assume that you have installed the system gcc
 # package this means that pcre is going to link against it, and it's ok in this
 # case

--- a/package-scripts/angry-omnibus-toolchain/postinst
+++ b/package-scripts/angry-omnibus-toolchain/postinst
@@ -15,7 +15,7 @@ error_exit()
   exit 1
 }
 
-for name in git ruby tar bash bundle curl fakeroot gem make makedepend patch pkg-config rake
+for name in git ruby tar bash berks bundle curl fakeroot gem make makedepend patch pkg-config rake
 do
 	ln -sf /opt/angry-omnibus-toolchain/embedded/bin/$name /opt/angry-omnibus-toolchain/bin || error_exit "Cannot link $name to /opt/angry-omnibus-toolchain/bin"
 done

--- a/package-scripts/omnibus-toolchain/postinst
+++ b/package-scripts/omnibus-toolchain/postinst
@@ -15,7 +15,7 @@ error_exit()
   exit 1
 }
 
-for name in git ruby tar bash bundle curl fakeroot gem make makedepend patch pkg-config rake
+for name in git ruby tar bash berks bundle curl fakeroot gem make makedepend patch pkg-config rake
 do
 	ln -sf /opt/omnibus-toolchain/embedded/bin/$name /opt/omnibus-toolchain/bin || error_exit "Cannot link $name to /opt/omnibus-toolchain/bin"
 done


### PR DESCRIPTION
This stretches the use case for the toolchain package a bit, but it's a pragmatic way to get berkshelf (which many Chef server projects are using to vendor cookbooks for packaging) on the builders.

cc @chef/engineering-services 