### PR TITLE
Only support Solaris 10u11 and newer

### DIFF
--- a/files/mapfiles/solaris
+++ b/files/mapfiles/solaris
@@ -1,6 +1,0 @@
-$mapfile_version 2
-DEPEND_VERSIONS libc.so {
-  ALLOW = SUNW_1.22.1;
-  ALLOW = SUNW_1.1;
-  ALLOW = SUNWprivate_1.1;
-};


### PR DESCRIPTION
This removes the mapfile which is no longer required in Solaris 10u11 and later.

Relates to COOL-502.