### PR TITLE
Update Rubygems to 2.6.10

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -34,7 +34,7 @@ build_iteration 1
 override :ruby,     version: "2.3.1"
 override :git,      version: "2.10.2"
 override :gtar,     version: "1.28"
-override :rubygems, version: "2.4.8"
+override :rubygems, version: "2.6.10"
 
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

This release of RubyGems fixes a number of bugs that will allow us to
unpin rainbow in chef and chefdk. Specifically,
https://github.com/sickill/rainbow/issues/44.

Signed-off-by: Tom Duffield <tom@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/engineering-services/projects/omnibus-toolchain/changes/f5c439b9-c532-4b12-b4c8-754c109682b3