### PR TITLE
Enable use of Windows omnibus-toolchain.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'omnibus',          git: 'https://github.com/chef/omnibus', branch: 'rhass/COOL-502_with_gcc_investigate'
-gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software', branch: 'shain/ruby_windows_monster+rhass'
+gem 'omnibus',          git: 'https://github.com/chef/omnibus'
+gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software'
 
 gem 'chefstyle', '~> 0.3'
 


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Ryan Hass

This removes the long-standing branch pinnings for omnibus and
omnibus-software, and allows use to build on omnibus-toolchain enabled
builders and testers.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>



Ready to merge? View this change in Chef Automate and click the Approve button: https://delivery.chef.co/e/chef/#/organizations/engineering-services/projects/omnibus-toolchain/changes/9153ef45-19b5-4242-9d77-a991d1cf78b9