### PR TITLE
A few documentation fixes to bring this up-to-date.

### DIFF
--- a/docs/Debian_Ubuntu_Linux.md
+++ b/docs/Debian_Ubuntu_Linux.md
@@ -21,15 +21,15 @@ zlib1g-dev git libffi6 libffi-dev
 Ruby environment
 ----------------
 
-Next, we need a temporary ruby environment. The omnibus software needs at least Ruby 2.1 in order to build correctly, but instead of depending on the OS version (since Ruby 2.1 is not available on all operating systems) we'll just build a temporary rbenv instead.
+Next, we need a temporary ruby environment. The omnibus software needs at least Ruby 2.2 in order to build correctly, but instead of depending on the OS version (since Ruby 2.2 is not available on all operating systems) we'll just build a temporary rbenv instead.
 
 ```shell
 git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
 git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
-export PATH="$HOME/.rbenv/bin:$PATH"
+export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
-rbenv install 2.1.2
-rbenv global 2.1.2
+rbenv install 2.2.3
+rbenv global 2.2.3
 gem install bundler
 ```
 
@@ -42,7 +42,7 @@ Now that all the pieces are in place, we can build the toolchain for real:
 git clone https://github.com/chef/omnibus-toolchain.git
 cd omnibus-toolchain
 bundle install --without development
-sudo ~/.rbenv/shims/bundle exec omnibus build omnibus-toolchain
+sudo env FORCE_UNSAFE_CONFIGURE=1 ~/.rbenv/shims/bundle exec omnibus build omnibus-toolchain
 ```
 
 That's it. At this point, the toolchain is installed in /opt/omnibus-toolchain and an DEB package for it is available in /var/cache/omnibus/pkg
@@ -55,4 +55,4 @@ All changes made to your environment for the rbenv installation were temporary a
 Common Problems
 ---------------
 
-On some platforms, the ffi rubygem will fail to compile it's native extensions. Most distributions include a version of libffi which has support for your platform, which we install as part of the preconditions above. However, it may be too old for the ffi rubygem. If this is the case, the best course of action is to install the latest version of [libffi](https://sourceware.org/libffi/) attempt to compile it and install it as root. If it's installed and visible via pkg-config then the ffi rubygem will use that instead of the older native code included within it's codebase.
+On some platforms, the ffi rubygem will fail to compile its native extensions. Most distributions include a version of libffi which has support for your platform, which we install as part of the preconditions above. However, it may be too old for the ffi rubygem. If this is the case, the best course of action is to install the latest version of [libffi](https://sourceware.org/libffi/) attempt to compile it and install it as root. If it's installed and visible via pkg-config then the ffi rubygem will use that instead of the older native code included within its codebase.


### PR DESCRIPTION
Going through this I found that Ruby 2.2 is at least required by the `omnibus` gem. I also had to use `FORCE_UNSAFE_CONFIGURE=1` otherwise `gtar` was really unhappy to run autoconf as root.