### PR TITLE
Use gtar 1.32

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -36,8 +36,8 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-override :ruby,     version: "2.6.3"
-override :gtar,     version: "1.28"
+override :ruby, version: "2.6.3"
+override :gtar, version: "1.32"
 # there's an issue with curl later versions (ntlm + smb) on AIX
 override :curl, version: '7.47.1'
 # riding berkshelf master is hard when you're at the edge of versions


### PR DESCRIPTION
This bump includes a *ton* of bugfixes and removes the need for 2 different patches to gtar (on macos/aix). This also fixes a CVE.

Signed-off-by: Tim Smith <tsmith@chef.io>