### PR TITLE
Pin tar to 1.28 for Ubuntu 14.04

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -37,7 +37,14 @@ else
 end
 
 override :ruby, version: "2.6.3"
-override :gtar, version: "1.32"
+
+# tar 1.32 is not compatible with the Ubuntu 14.04's latest version of dpkg-deb so pin it to 1.29
+if ubuntu_trusty?
+  override :gtar, version: "1.29"
+else
+  override :gtar, version: "1.32"
+end
+
 # there's an issue with curl later versions (ntlm + smb) on AIX
 override :curl, version: '7.47.1'
 # riding berkshelf master is hard when you're at the edge of versions


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Tar 1.32 is not compatible with the Ubuntu 14.04's latest version of
dpkg-deb so pin it to 1.28, the last known working version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
