### PR TITLE
Make Ubuntu 14.04 use tar 1.28

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -38,9 +38,9 @@ end
 
 override :ruby, version: "2.6.3"
 
-# tar 1.32 is not compatible with the Ubuntu 14.04's latest version of dpkg-deb so pin it to 1.29
+# tar 1.32 is not compatible with the Ubuntu 14.04's latest version of dpkg-deb so pin it to 1.28
 if ubuntu_trusty?
-  override :gtar, version: "1.29"
+  override :gtar, version: "1.28"
 else
   override :gtar, version: "1.32"
 end

--- a/config/software/gtar.rb
+++ b/config/software/gtar.rb
@@ -1,0 +1,61 @@
+#
+# Copyright 2016-2019 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "gtar"
+default_version "1.30"
+
+version("1.32") { source sha256: "b59549594d91d84ee00c99cf2541a3330fed3a42c440503326dab767f2fbb96c" }
+version("1.30") { source sha256: "4725cc2c2f5a274b12b39d1f78b3545ec9ebb06a6e48e8845e1995ac8513b088" }
+version("1.29") { source sha256: "cae466e6e58c7292355e7080248f244db3a4cf755f33f4fa25ca7f9a7ed09af0" }
+version("1.28") { source md5: "6ea3dbea1f2b0409b234048e021a9fd7" }
+
+license "GPL-3.0"
+license_file "COPYING"
+
+source url: "http://ftp.gnu.org/gnu/tar/tar-#{version}.tar.gz"
+
+relative_path "tar-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  configure_command = [
+    "./configure",
+    "--prefix=#{install_dir}/embedded",
+  ]
+
+  # First off let's disable selinux support, as it causes issues on some platforms
+  # We're not doing it on every platform because this breaks on OSX
+  unless osx?
+    configure_command << " --without-selinux"
+  end
+
+  if nexus? || ios_xr? || s390x?
+    # ios_xr and nexus don't support posix acls
+    configure_command << " --without-posix-acls"
+  elsif aix?
+    if version.satisfies?("> 1.28") && version.satisfies?("< 1.32")
+      # xlc doesn't allow duplicate entries in case statements
+      patch_env = env.dup
+      patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
+      patch source: "aix_extra_case.patch", plevel: 0, env: patch_env
+    end
+  end
+
+  command configure_command.join(" "), env: env
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

In https://github.com/chef/omnibus-toolchain/pull/115 I accidentally said in the PR description that I was pinning tar to 1.28 but I actually pinned it to 1.29 because it was the oldest tar available in the latest omnibus-software. After doing a number of builds of a few of our omnibus projects I'm consistently seeing unexpected results. The Ubuntu 14.04 package sizes are consistently around 1 - 2 GB and testing those packages consistently fails. I believe that we need to pin tar back to 1.28 which we know was working so I copied omnibus-software's gtar software config file into this repo and added metadata for version 1.28.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
