### PR TITLE
Fix platform names in [angry-]release.omnibus.yml files

### DIFF
--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -9,8 +9,8 @@ builder-to-testers-map:
   debian-8-x86_64:
     - debian-8-x86_64
     - debian-9-x86_64
-  el-6-i386:
-    - el-6-i386
+  el-6-i686:
+    - el-6-i686
   el-6-s390x:
     - el-6-s390x
   el-6-x86_64:
@@ -25,9 +25,9 @@ builder-to-testers-map:
     - el-7-s390x
   el-7-x86_64:
     - el-7-x86_64
-  freebsd-10-x86_64:
-    - freebsd-10-x86_64
-    - freebsd-11-x86_64
+  freebsd-10-amd64:
+    - freebsd-10-amd64
+    - freebsd-11-amd64
   mac_os_x-10.12-x86_64:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
@@ -41,10 +41,10 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  solaris-11-i86pc:
-    - solaris-11-i86pc
-  solaris-11-sparc:
-    - solaris-11-sparc
+  solaris2-5.11-i386:
+    - solaris2-5.11-i386
+  solaris2-5.11-sparc:
+    - solaris2-5.11-sparc
   ubuntu-14.04-i386:
     - ubuntu-14.04-i386
   ubuntu-14.04-ppc64le:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,8 +9,8 @@ builder-to-testers-map:
   debian-8-x86_64:
     - debian-8-x86_64
     - debian-9-x86_64
-  el-6-i386:
-    - el-6-i386
+  el-6-i686:
+    - el-6-i686
   el-6-s390x:
     - el-6-s390x
   el-6-x86_64:
@@ -26,9 +26,9 @@ builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
-  freebsd-10-x86_64:
-    - freebsd-10-x86_64
-    - freebsd-11-x86_64
+  freebsd-10-amd64:
+    - freebsd-10-amd64
+    - freebsd-11-amd64
   mac_os_x-10.12-x86_64:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
@@ -42,10 +42,10 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  solaris-11-i86pc:
-    - solaris-11-i86pc
-  solaris-11-sparc:
-    - solaris-11-sparc
+  solaris2-5.11-i386:
+    - solaris2-5.11-i386
+  solaris2-5.11-sparc:
+    - solaris2-5.11-sparc
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'omnibus',          git: 'https://github.com/chef/omnibus'
 gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software'
+gem 'artifactory'
 
 gem 'chefstyle'
 


### PR DESCRIPTION
## Description

Fix platform names in `angry-release.omnibus.yml` and `release.omnibus.yml` files to conform with what the new package publishing code in the omnibus gem expects and install the artifactory gem so it can be used by the package publishing code.

## Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
