### PR TITLE
Remove support for RHEL 6 s390x (zLinux)

### DIFF
--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -12,8 +12,6 @@ builder-to-testers-map:
     - debian-9-x86_64
   el-6-i686:
     - el-6-i686
-  el-6-s390x:
-    - el-6-s390x
   el-6-x86_64:
     - el-6-x86_64
   el-7-aarch64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -12,8 +12,6 @@ builder-to-testers-map:
     - debian-9-x86_64
   el-6-i686:
     - el-6-i686
-  el-6-s390x:
-    - el-6-s390x
   el-6-x86_64:
     - el-6-x86_64
   el-7-aarch64:


### PR DESCRIPTION
IBM is retiring support for RHEL 6 in Linux One cloud on Jan 17th 2020
where these systems are currently hosted,
so we are no longer able to support this platform in our build matrix.

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

Remove support for RHEL 6 s390x (zLinux)

## Description
IBM is retiring support for RHEL 6 in their hosted Linux One cloud on Jan 17th 2020,
so we are no longer able to support this platform in our build matrix.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
