### PR TITLE
Pin bundler to same version as the one shipped with ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'omnibus',          git: 'https://github.com/chef/omnibus'
-gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software'
+gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software', branch: 'jsinha/remove_bundler_dependencies'
 gem 'artifactory'
 
 gem 'chefstyle'

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -36,7 +36,8 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-override :ruby, version: "2.6.3"
+override :ruby, version: "2.6.5"
+override :bundler, version: "1.17.3"
 
 # tar 1.32 is not compatible with the Ubuntu 14.04's latest version of dpkg-deb so pin it to 1.28
 if ubuntu_trusty?

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -45,9 +45,6 @@ else
   override :gtar, version: "1.32"
 end
 
-# riding berkshelf master is hard when you're at the edge of versions
-override :berkshelf, version: "v7.0.8"
-
 # creates required build directories
 dependency "preparation"
 

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -37,7 +37,6 @@ else
 end
 
 override :ruby, version: "2.6.5"
-override :bundler, version: "1.17.3"
 
 # tar 1.32 is not compatible with the Ubuntu 14.04's latest version of dpkg-deb so pin it to 1.28
 if ubuntu_trusty?

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -38,8 +38,6 @@ dependency "cacerts"
 
 # ruby core tools
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 if linux? || mac_os_x?
   dependency "berkshelf" unless i386? || ios_xr? || nexus? || armhf?
@@ -57,7 +55,7 @@ end
 # For Solaris 10 and Freebsd 9 we assume that you have installed the system gcc
 # package this means that pcre is going to link against it, and it's ok in this
 # case
-if solaris2? || (freebsd? && ohai["os_version"].to_i < 1000024)
+if solaris2?
   whitelist_file /libpcrecpp\.so\..+/
 end
 

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -39,6 +39,9 @@ dependency "cacerts"
 # ruby core tools
 dependency "ruby"
 
+# pin bundler dependency to same version as the one shipped with ruby
+dependency "bundler", "= 1.17.3"
+
 if linux? || mac_os_x?
   dependency "berkshelf" unless i386? || ios_xr? || nexus? || armhf?
 end

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -52,6 +52,7 @@ else
   dependency "helper-sh"
 end
 
+dependency "ruby-cleanup"
 # For Solaris 10 and Freebsd 9 we assume that you have installed the system gcc
 # package this means that pcre is going to link against it, and it's ok in this
 # case

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -39,9 +39,6 @@ dependency "cacerts"
 # ruby core tools
 dependency "ruby"
 
-# pin bundler dependency to same version as the one shipped with ruby
-dependency "bundler", "= 1.17.3"
-
 if linux? || mac_os_x?
   dependency "berkshelf" unless i386? || ios_xr? || nexus? || armhf?
 end

--- a/omnibus-test.sh
+++ b/omnibus-test.sh
@@ -65,6 +65,17 @@ BINDIR="$INSTALL_DIR/bin/"
 "$BINDIR/ruby" --version
 "$BINDIR/tar" --version
 
+# Verify that default bundle version is the same as the one installed with ruby
+bundle_version=$("$BINDIR/bundle" --version)
+rb_bundle_version=$("$BINDIR/gem" list bundler |awk -F"default:" '{print $2}'| tr -d '[:space:]'))
+default_bundle_version="${rb_bundle_version//)}"
+
+if [ "$bundle_version" != "$default_bundle_version" ]; then
+    echo "Default bundler version is not same as the one installed with ruby!!"
+    echo "Update bunlder pinning in omnibus-toolchain to resolve this error"
+    exit 1
+fi
+
 export PATH="$BINDIR:$PATH"
 
 cd "$TMPDIR"

--- a/omnibus-test.sh
+++ b/omnibus-test.sh
@@ -66,9 +66,9 @@ BINDIR="$INSTALL_DIR/bin/"
 "$BINDIR/tar" --version
 
 # Verify that default bundle version is the same as the one installed with ruby
-bundle_version=$("$BINDIR/bundle" --version)
-rb_bundle_version=$("$BINDIR/gem" list bundler |awk -F"default:" '{print $2}'| tr -d '[:space:]'))
-default_bundle_version="${rb_bundle_version//)}"
+bundler_version=$("$BINDIR/bundle" --version |awk -F"version " '{print $2}'| tr -d '[:space:]')
+rb_bundler_version=$("$BINDIR/gem" list bundler |awk -F"default:" '{print $2}'| tr -d '[:space:]')
+default_bundler_version="${rb_bundler_version//)}"
 
 if [ "$bundle_version" != "$default_bundle_version" ]; then
     echo "Default bundler version is not same as the one installed with ruby!!"

--- a/omnibus-test.sh
+++ b/omnibus-test.sh
@@ -65,17 +65,6 @@ BINDIR="$INSTALL_DIR/bin/"
 "$BINDIR/ruby" --version
 "$BINDIR/tar" --version
 
-# Verify that default bundle version is the same as the one installed with ruby
-bundler_version=$("$BINDIR/bundle" --version |awk -F"version " '{print $2}'| tr -d '[:space:]')
-rb_bundler_version=$("$BINDIR/gem" list bundler |awk -F"default:" '{print $2}'| tr -d '[:space:]')
-default_bundler_version="${rb_bundler_version//)}"
-
-if [ "$bundle_version" != "$default_bundle_version" ]; then
-    echo "Default bundler version is not same as the one installed with ruby!!"
-    echo "Update bunlder pinning in omnibus-toolchain to resolve this error"
-    exit 1
-fi
-
 export PATH="$BINDIR:$PATH"
 
 cd "$TMPDIR"


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Pin bundler to same version as the one shipped with ruby

## Related Issue
Currently installed bundler version does not match the version shipped with default ruby(1.17.3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
