### PR TITLE
Add Ubuntu 18.04 (aarch64) support

### DIFF
--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -45,6 +45,8 @@ builder-to-testers-map:
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
+  ubuntu-18.04-aarch64:
+    - ubuntu-18.04-aarch64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -45,6 +45,8 @@ builder-to-testers-map:
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
+  ubuntu-18.04-aarch64:
+    - ubuntu-18.04-aarch64
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:


### PR DESCRIPTION
## Description

This PR just adds the new Ubuntu 18.04 (aarch64) builder/tester to the Omnibus pipelines.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
