### PR TITLE
Add Finder auth flow helper script

### DIFF
--- a/config/software/helper-macos.rb
+++ b/config/software/helper-macos.rb
@@ -1,0 +1,33 @@
+#
+# Copyright Progress Software Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "helper-macos"
+
+source path: "#{project.files_path}/helper-macos"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+build do
+
+  %w(
+    finder-auth-flow.scpt
+  ).each do |helper|
+    erb source: "#{helper}.erb",
+        dest: "#{install_dir}/bin/#{helper}",
+        mode: 0755
+  end
+end

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -52,6 +52,10 @@ else
   dependency "helper-sh"
 end
 
+if darwin?
+  dependency "helper-macos"
+end
+
 # For Solaris 10 and Freebsd 9 we assume that you have installed the system gcc
 # package this means that pcre is going to link against it, and it's ok in this
 # case

--- a/config/templates/helper-macos/finder-auth-flow.scpt.erb
+++ b/config/templates/helper-macos/finder-auth-flow.scpt.erb
@@ -1,0 +1,7 @@
+-- This code will force the MacOS authentication flow that will allow Omnibus to control
+-- the Finder window. Run this as the process which executes your Omnibus builds.
+tell application "Finder"
+	reopen
+	activate
+	set selection to {}
+end tell


### PR DESCRIPTION
This script will force MacOS into the authentication flow used by the
Omnibus DMG compressor. By executing this script, we can pre-authorize
machines so that the Omnibus builds do not hang and fail.

This resulting authentication flow needs to be accepted through the UI.
There is no way to programatically accept the auth flow at this time.

Signed-off-by: Tom Duffield <tom@chef.io>