### PR TITLE
Update openssl to 1.1.1j and ruby to 2.7.2 to enable m1 mac builds

### DIFF
--- a/.expeditor/angry-release-canary.omnibus.yml
+++ b/.expeditor/angry-release-canary.omnibus.yml
@@ -32,8 +32,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  # mac_os_x-10.13-x86_64:
-  #   - mac_os_x-10.13-x86_64
+  # mac_os_x-10.14-x86_64:
   #   - mac_os_x-10.14-x86_64
   #   - mac_os_x-10.15-x86_64
   # sles-12-s390x:

--- a/.expeditor/angry-release-canary.omnibus.yml
+++ b/.expeditor/angry-release-canary.omnibus.yml
@@ -32,9 +32,12 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  # mac_os_x-10.14-x86_64:
-  #   - mac_os_x-10.14-x86_64
-  #   - mac_os_x-10.15-x86_64
+  mac_os_x-10.14-x86_64:
+    - mac_os_x-10.14-x86_64
+    - mac_os_x-10.15-x86_64
+    - mac_os_x-11-x86_64
+  mac_os_x-11-arm64:
+    - mac_os_x-11-arm64
   # sles-12-s390x:
   #   - sles-12-s390x
   sles-12-x86_64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -33,8 +33,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  mac_os_x-10.13-x86_64:
-    - mac_os_x-10.13-x86_64
+  mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11.0-x86_64

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -36,7 +36,9 @@ builder-to-testers-map:
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
-    - mac_os_x-11.0-x86_64
+    - mac_os_x-11-x86_64
+  mac_os_x-11-arm64:
+    - mac_os_x-11-arm64
   sles-12-s390x:
     - sles-12-s390x
     - sles-15-s390x

--- a/.expeditor/release-canary.omnibus.yml
+++ b/.expeditor/release-canary.omnibus.yml
@@ -32,8 +32,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  # mac_os_x-10.13-x86_64:
-  #   - mac_os_x-10.13-x86_64
+  # mac_os_x-10.14-x86_64:
   #   - mac_os_x-10.14-x86_64
   #   - mac_os_x-10.15-x86_64
   #   - mac_os_x-11.0-x86_64

--- a/.expeditor/release-canary.omnibus.yml
+++ b/.expeditor/release-canary.omnibus.yml
@@ -32,10 +32,12 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  # mac_os_x-10.14-x86_64:
-  #   - mac_os_x-10.14-x86_64
-  #   - mac_os_x-10.15-x86_64
-  #   - mac_os_x-11.0-x86_64
+  mac_os_x-10.14-x86_64:
+    - mac_os_x-10.14-x86_64
+    - mac_os_x-10.15-x86_64
+    - mac_os_x-11-x86_64
+  mac_os_x-11-arm64:
+    - mac_os_x-11-arm64
   # sles-12-s390x:
   #   - sles-12-s390x
   sles-12-x86_64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -33,8 +33,7 @@ builder-to-testers-map:
   freebsd-11-amd64:
     - freebsd-11-amd64
     - freebsd-12-amd64
-  mac_os_x-10.13-x86_64:
-    - mac_os_x-10.13-x86_64
+  mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11.0-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -36,7 +36,9 @@ builder-to-testers-map:
   mac_os_x-10.14-x86_64:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
-    - mac_os_x-11.0-x86_64
+    - mac_os_x-11-x86_64
+  mac_os_x-11-arm64:
+    - mac_os_x-11-arm64
   sles-12-s390x:
     - sles-12-s390x
     - sles-15-s390x

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -36,7 +36,7 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-override :ruby, version: "2.6.5"
+override :ruby, version: "2.7.2"
 override :bundler, version: "1.17.2"
 override :gtar, version: "1.32"
 

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -40,6 +40,9 @@ override :ruby, version: "2.6.5"
 override :bundler, version: "1.17.2"
 override :gtar, version: "1.32"
 
+# 1.1.1i+ builds on m1 mac
+override :openssl, version: "1.1.1j"
+
 # Solaris fails compile on libtool version 2.4.2 and 2.4.6
 if solaris?
   override :libtool, version: "2.4"

--- a/resources/omnibus-toolchain/pkg/entitlements.plist
+++ b/resources/omnibus-toolchain/pkg/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
Updates to enable darwin/arm64 (M1) builds:
* Update openssl to 1.1.1i
* Update ruby to 2.7.2

Also: remove macOS 10.13 from the build matrices