### PR TITLE
Stop producing builds for Debian 8

### DIFF
--- a/.expeditor/angry-release-canary.omnibus.yml
+++ b/.expeditor/angry-release-canary.omnibus.yml
@@ -7,8 +7,7 @@ builder-to-testers-map:
   # aix-7.1-powerpc:
   #   - aix-7.1-powerpc
   #   - aix-7.2-powerpc
-  debian-8-x86_64:
-    - debian-8-x86_64
+  debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
   debian-10-aarch64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -7,8 +7,7 @@ builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
-  debian-8-x86_64:
-    - debian-8-x86_64
+  debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
   debian-10-aarch64:

--- a/.expeditor/release-canary.omnibus.yml
+++ b/.expeditor/release-canary.omnibus.yml
@@ -7,8 +7,7 @@ builder-to-testers-map:
   # aix-7.1-powerpc:
   #   - aix-7.1-powerpc
   #   - aix-7.2-powerpc
-  debian-8-x86_64:
-    - debian-8-x86_64
+  debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
   debian-10-aarch64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -7,8 +7,7 @@ builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc
     - aix-7.2-powerpc
-  debian-8-x86_64:
-    - debian-8-x86_64
+  debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
   debian-10-aarch64:


### PR DESCRIPTION
We don't support Debian 8 anywhere at this point.

Signed-off-by: Tim Smith <tsmith@chef.io>