### PR TITLE
Add berkshelf to omnibus toolchain

### DIFF
--- a/config/software/helper-gems.rb
+++ b/config/software/helper-gems.rb
@@ -26,4 +26,5 @@ build do
   gem "install --no-document artifactory", env: env
   gem "install --no-document mixlib-install", env: env
   gem "install --no-document omnibus", env: env
+  gem "install --no-document berkshelf", env: env
 end


### PR DESCRIPTION
This is used by Server, Supermarket, Manage, and Backend for the build
time installation of gems. If we move it to toolchain then we can avoid
installing a ton of deps into our packages and also unblock supermarket
and manage which are totally broken trying to install Berkshelf right
now.

Signed-off-by: Tim Smith <tsmith@chef.io>