### PR TITLE
Fix aix builds

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -40,7 +40,7 @@ override :ruby, version: "2.7.2"
 override :gtar, version: "1.32"
 
 # 1.1.1i+ builds on m1 mac
-override :openssl, version: "1.1.1j"
+override :openssl, version: "1.1.1k"
 
 if aix?
   override :expat, version: "2.1.0"

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -63,6 +63,8 @@ dependency "preparation"
 # a custom whitelist
 dependency "omnibus-toolchain"
 
+dependency "ruby-cleanup"
+
 exclude '\.git*'
 exclude 'bundler\/git'
 

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -37,7 +37,6 @@ else
 end
 
 override :ruby, version: "2.7.2"
-override :bundler, version: "1.17.2"
 override :gtar, version: "1.32"
 
 # 1.1.1i+ builds on m1 mac

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -43,6 +43,10 @@ override :gtar, version: "1.32"
 # 1.1.1i+ builds on m1 mac
 override :openssl, version: "1.1.1j"
 
+if aix?
+  override :expat, version: "2.1.0"
+end
+
 if solaris?
   override :git, version: "2.24.1"
 end

--- a/omnibus-test.ps1
+++ b/omnibus-test.ps1
@@ -1,10 +1,10 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$Env:PATH = "C:\opscode\$product\embedded\bin;$Env:PATH"
+$Env:PATH = "C:\opscode\$Env:PRODUCT\embedded\bin;$Env:PATH"
 
-$embedded_bin_dir = "C:\opscode\$product\embedded\bin"
-$project_bin_dir = "C:\opscode\$product\bin"
+$embedded_bin_dir = "C:\opscode\$Env:PRODUCT\embedded\bin"
+$project_bin_dir = "C:\opscode\$Env:PRODUCT\bin"
 
 # Exercise various packaged tools to validate binstub shebangs
 & $embedded_bin_dir\ruby --version


### PR DESCRIPTION
Pin expat to 2.1.0 for aix builds

Fix omnibus-test.ps1

Add dependency on ruby-cleanup. This removes a lot of unnecessary files, some of which were causing Apple notarization failures.

Remove bundler 1.x to satisfy ruby-cleanup.rb. We only need the bundler that comes with the ruby install.

Bump openssl to 1.1.k