### PR TITLE
Remove workaround for Solaris 10 / FreeBSD 9

### DIFF
--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -52,13 +52,6 @@ else
   dependency "helper-sh"
 end
 
-# For Solaris 10 and Freebsd 9 we assume that you have installed the system gcc
-# package this means that pcre is going to link against it, and it's ok in this
-# case
-if solaris2? || (freebsd? && ohai["os_version"].to_i < 1000024)
-  whitelist_file /libpcrecpp\.so\..+/
-end
-
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 


### PR DESCRIPTION
This is EOL beyond EOL.

Signed-off-by: Tim Smith <tsmith@chef.io>