### PR TITLE
Stop building on EOL Ubuntu 16.04

### DIFF
--- a/.expeditor/angry-release-canary.omnibus.yml
+++ b/.expeditor/angry-release-canary.omnibus.yml
@@ -49,8 +49,7 @@ builder-to-testers-map:
   #   - solaris2-5.11-i386
   # solaris2-5.11-sparc:
   #   - solaris2-5.11-sparc
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   ubuntu-18.04-aarch64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -51,8 +51,7 @@ builder-to-testers-map:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   ubuntu-18.04-aarch64:

--- a/.expeditor/release-canary.omnibus.yml
+++ b/.expeditor/release-canary.omnibus.yml
@@ -49,8 +49,7 @@ builder-to-testers-map:
   #   - solaris2-5.11-i386
   # solaris2-5.11-sparc:
   #   - solaris2-5.11-sparc
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   ubuntu-18.04-aarch64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -51,8 +51,7 @@ builder-to-testers-map:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
   ubuntu-18.04-aarch64:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,8 +29,6 @@ platforms:
     run_list:
       - freebsd::portsnap
       - freebsd::pkgng
-  - name: ubuntu-16.04
-    run_list: apt::default
   - name: ubuntu-18.04
     run_list: apt::default
   - name: windows-2012r2


### PR DESCRIPTION
We don't support Ubuntu 16.04 anymore

Signed-off-by: Tim Smith <tsmith@chef.io>