### PR TITLE
Remove gtar check for < 1.32

### DIFF
--- a/config/software/gtar.rb
+++ b/config/software/gtar.rb
@@ -42,13 +42,6 @@ build do
 
   if s390x?
     configure_command << " --without-posix-acls"
-  elsif aix?
-    if version.satisfies?("> 1.28") && version.satisfies?("< 1.32")
-      # xlc doesn't allow duplicate entries in case statements
-      patch_env = env.dup
-      patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
-      patch source: "aix_extra_case.patch", plevel: 0, env: patch_env
-    end
   end
 
   command configure_command.join(" "), env: env

--- a/config/software/helper-gems.rb
+++ b/config/software/helper-gems.rb
@@ -26,5 +26,4 @@ build do
   gem "install --no-document artifactory", env: env
   gem "install --no-document mixlib-install", env: env
   gem "install --no-document omnibus", env: env
-  gem "install --no-document berkshelf", env: env
 end

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -43,6 +43,8 @@ dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
 
+dependency "berkshelf"
+
 # Include helpers for build pipelines
 dependency "helper-gems"
 


### PR DESCRIPTION
We only have 1.32 so this is pointless.

Signed-off-by: Tim Smith <tsmith@chef.io>