### PR TITLE
Build nokogiri later to optimize omnibus cache

### DIFF
--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -19,7 +19,6 @@ default_version "1.0.0"
 
 license :project_license
 
-dependency "nokogiri"
 
 # gnu utilities
 if windows?
@@ -40,6 +39,8 @@ dependency "cacerts"
 
 # ruby core tools
 dependency "ruby"
+
+dependency "nokogiri"
 
 dependency "berkshelf"
 


### PR DESCRIPTION
nokogiri doesn't have a version set so it always dirties the omnibus cache. If we move it down the list of dependencies we can dirty less of the cache.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>