### PR TITLE
Only build berkshelf on specific platforms

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -16,27 +16,35 @@ slack:
     - releng-notify
 
 pipelines:
-  - omnibus/release
+  - omnibus/release:
+      env:
+        - IGNORE_CACHE: true
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
-  - omnibus/angry-release
+        - IGNORE_CACHE: true
+  - omnibus/angry-release:
+      env:
+        - IGNORE_CACHE: true
   - omnibus/angry-adhoc:
       definition: .expeditor/angry-release.omnibus.yml
       env:
         - ADHOC: true
+        - IGNORE_CACHE: true
   # the canary pipelines are used for testing by our *-buildkite-pipelines repos
   - omnibus/adhoc-canary:
       canary: true
       definition: .expeditor/release-canary.omnibus.yml
       env:
         - ADHOC: true
+        - IGNORE_CACHE: true
   - omnibus/angry-adhoc-canary:
       canary: true
       definition: .expeditor/angry-release-canary.omnibus.yml
       env:
         - ADHOC: true
+        - IGNORE_CACHE: true
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -39,6 +39,9 @@ end
 override :ruby, version: "2.7.4"
 override :gtar, version: "1.32"
 
+# riding berkshelf master is hard when you're at the edge of versions
+override :berkshelf, version: "v7.2.2"
+
 # 1.1.1i+ builds on m1 mac
 override :openssl, version: "1.1.1k"
 

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -40,9 +40,13 @@ dependency "cacerts"
 # ruby core tools
 dependency "ruby"
 
-dependency "nokogiri"
+# Projects such as Chef Server, Supermarket, Chef Manage and Chef Backend use berkshelf for the build time installation of gems.
+# Moving it to toolchain avoids installing a ton of deps into our packages.
+if linux? || macos?
+  dependency "berkshelf" unless i386? || arm?
+end
 
-dependency "berkshelf"
+dependency "nokogiri"
 
 # Include helpers for build pipelines
 dependency "helper-gems"

--- a/omnibus-test.sh
+++ b/omnibus-test.sh
@@ -17,11 +17,10 @@ sudo rm -rf "$TMPDIR"
 mkdir -p "$TMPDIR"
 
 BINDIR="$INSTALL_DIR/bin/"
-EMBEDDED_BINDIR="$INSTALL_DIR/embedded/bin/"
 
 # Explicitly call the one we expect to be there.
 "$BINDIR/bash" --version
-"$EMBEDDED_BINDIR/berks" --version
+"$BINDIR/berks" --version || true # not on non-linux
 "$BINDIR/bundle" --version
 "$BINDIR/curl" --version
 "$BINDIR/gem" --version

--- a/package-scripts/angry-omnibus-toolchain/postinst
+++ b/package-scripts/angry-omnibus-toolchain/postinst
@@ -15,7 +15,7 @@ error_exit()
   exit 1
 }
 
-for name in git ruby tar bash bundle curl gem make makedepend patch pkg-config rake
+for name in git ruby tar bash berks bundle curl gem make makedepend patch pkg-config rake
 do
 	ln -sf /opt/angry-omnibus-toolchain/embedded/bin/$name /opt/angry-omnibus-toolchain/bin || error_exit "Cannot link $name to /opt/angry-omnibus-toolchain/bin"
 done

--- a/package-scripts/omnibus-toolchain/postinst
+++ b/package-scripts/omnibus-toolchain/postinst
@@ -15,7 +15,7 @@ error_exit()
   exit 1
 }
 
-for name in git ruby tar bash bundle curl gem make makedepend patch pkg-config rake
+for name in git ruby tar bash berks bundle curl gem make makedepend patch pkg-config rake
 do
 	ln -sf /opt/omnibus-toolchain/embedded/bin/$name /opt/omnibus-toolchain/bin || error_exit "Cannot link $name to /opt/omnibus-toolchain/bin"
 done


### PR DESCRIPTION
Move berkshelf build above nokogiri for omnibus cache optimization.

Pin berkshelf.

Symlink berks into BINDIR.