### PR TITLE
Fix platforms in canary pipelines

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -41,9 +41,9 @@ builder-to-testers-map:
     - mac_os_x-10.14-x86_64
     - mac_os_x-10.15-x86_64
     - mac_os_x-11-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
-    - mac_os_x-12-arm64
+  # mac_os_x-11-arm64:        # canary org's macos 11 arm64 omnibus worker uses omnibus-toolchain so it cannot be used to build omnibus-toolchain
+  #   - mac_os_x-11-arm64
+  #   - mac_os_x-12-arm64     # canary org doesn't yet have a macos 12 arm64 omnibus worker
   # sles-12-s390x:
   #   - sles-12-s390x
   #   - sles-15-s390x

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -43,7 +43,7 @@ builder-to-testers-map:
     - mac_os_x-11-x86_64
   mac_os_x-11-arm64:
     - mac_os_x-11-arm64
-    - mac_os_x-12-arm64
+  #   - mac_os_x-12-arm64     # canary org doesn't yet have a macos 12 arm64 omnibus worker
   # sles-12-s390x:
   #   - sles-12-s390x
   #   - sles-15-s390x

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -35,13 +35,13 @@ pipelines:
   # the canary pipelines are used for testing by our *-buildkite-pipelines repos
   - omnibus/adhoc-canary:
       canary: true
-      definition: .expeditor/release-canary.omnibus.yml
+      definition: .expeditor/adhoc-canary.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
   - omnibus/angry-adhoc-canary:
       canary: true
-      definition: .expeditor/angry-release-canary.omnibus.yml
+      definition: .expeditor/angry-adhoc-canary.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true


### PR DESCRIPTION
macos 12 arm64 worker doesn't exist in canary org

canary org's macos 11 arm64 omnibus worker uses omnibus-toolchain
so it cannot be used to build omnibus-toolchain

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>