### PR TITLE
Add ubuntu 1604 to build matrix

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -56,7 +56,8 @@ builder-to-testers-map:
   #   - solaris2-5.11-i386
   # solaris2-5.11-sparc:
   #   - solaris2-5.11-sparc
-  ubuntu-18.04-aarch64:
+  ubuntu-16.04-aarch64:
+    - ubuntu-16.04-aarch64
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
   ubuntu-18.04-x86_64:

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -56,7 +56,8 @@ builder-to-testers-map:
   #   - solaris2-5.11-i386
   # solaris2-5.11-sparc:
   #   - solaris2-5.11-sparc
-  ubuntu-18.04-aarch64:
+  ubuntu-16.04-aarch64:
+    - ubuntu-16.04-aarch64
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
   ubuntu-18.04-x86_64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -56,7 +56,8 @@ builder-to-testers-map:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
-  ubuntu-18.04-aarch64:
+  ubuntu-16.04-aarch64:
+    - ubuntu-16.04-aarch64
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
   ubuntu-18.04-x86_64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -56,7 +56,8 @@ builder-to-testers-map:
     - solaris2-5.11-i386
   solaris2-5.11-sparc:
     - solaris2-5.11-sparc
-  ubuntu-18.04-aarch64:
+  ubuntu-16.04-aarch64:
+    - ubuntu-16.04-aarch64
     - ubuntu-18.04-aarch64
     - ubuntu-20.04-aarch64
   ubuntu-18.04-x86_64:


### PR DESCRIPTION
Canonical extended support for Ubuntu 16.04 until 2026 so
we need to build Chef Infra on it.

https://github.com/chef/chef/pull/12086
Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>