### PR TITLE
Pin ohai to 16.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ group :development do
   gem 'winrm-fs'
   gem 'kitchen-zone'
   gem 'kitchen-vagrant'
+  gem 'ohai', '~> 16.17'  #pin ohai to 16.17.0
 end


### PR DESCRIPTION
Build is failing with below error - 

```
An error occurred while installing ohai (17.7.8), and Bundler cannot continue.
Make sure that `gem install ohai -v '17.7.8' --source 'https://rubygems.org/'` succeeds before bundling.
 
In Gemfile:
  omnibus-software was resolved to 4.0.0, which depends on
    omnibus was resolved to 8.2.6, which depends on
      ohai

```



Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
https://buildkite.com/chef/chef-omnibus-toolchain-main-omnibus-angry-adhoc/builds/95#bc2de139-01f3-441f-a678-277b03d756b3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
