### PR TITLE
Remove aix and powerpc from build matrix

### DIFF
--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -4,9 +4,9 @@ config: omnibus.rb
 test-path: omnibus-test.sh
 test-path-windows: omnibus-test.ps1
 builder-to-testers-map:
-  aix-7.1-powerpc:
-    - aix-7.1-powerpc
-    - aix-7.2-powerpc
+  # aix-7.1-powerpc:
+  #   - aix-7.1-powerpc
+  #   - aix-7.2-powerpc
   debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
@@ -21,10 +21,10 @@ builder-to-testers-map:
     - amazon-2-aarch64
   el-8-aarch64:
     - el-8-aarch64
-  el-7-ppc64:
-    - el-7-ppc64
-  el-7-ppc64le:
-    - el-7-ppc64le
+  # el-7-ppc64:
+  #   - el-7-ppc64
+  # el-7-ppc64le:
+  #   - el-7-ppc64le
   el-7-s390x:
     - el-7-s390x
     - el-8-s390x

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -4,9 +4,9 @@ config: omnibus.rb
 test-path: omnibus-test.sh
 test-path-windows: omnibus-test.ps1
 builder-to-testers-map:
-  aix-7.1-powerpc:
-    - aix-7.1-powerpc
-    - aix-7.2-powerpc
+  # aix-7.1-powerpc:
+  #   - aix-7.1-powerpc
+  #   - aix-7.2-powerpc
   debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
@@ -21,10 +21,10 @@ builder-to-testers-map:
     - amazon-2-aarch64
   el-8-aarch64:
     - el-8-aarch64
-  el-7-ppc64:
-    - el-7-ppc64
-  el-7-ppc64le:
-    - el-7-ppc64le
+  # el-7-ppc64:
+  #   - el-7-ppc64
+  # el-7-ppc64le:
+  #   - el-7-ppc64le
   el-7-s390x:
     - el-7-s390x
     - el-8-s390x


### PR DESCRIPTION
We are currently using temporary powerpc and AIX systems for builds. We only have enough systems to build angry-omnibus-toolchain. We do not have enough to also build the regular omnibus-toolchain.
We are also having trouble building omnibus-toolchain on the temporary AIX systems.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>