### PR TITLE
Limit workers on AIX

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -46,7 +46,7 @@ s3_bucket      'opscode-omnibus-cache'
 # ------------------------------
 build_retries 0
 fetcher_read_timeout 120
-#workers 10
+workers 8 if aix?
 
 # Load additional software
 # ------------------------------


### PR DESCRIPTION
Our AIX systems in IBM cloud can't reliably handle the default number of workers.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>