### PR TITLE
Unpin ohai in omnibus Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,4 @@ group :development do
   gem 'winrm-fs'
   gem 'kitchen-zone'
   gem 'kitchen-vagrant'
-  gem 'ohai', '~> 16.17'  #pin ohai to 16.17.0
 end


### PR DESCRIPTION
A new version of omnibus-toolchain is deployed on all platforms. The new version includes ruby 2.7 so we no longer need to pin to an old version of ohai.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>