### PR TITLE
Fix regressions

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -45,6 +45,10 @@ override :berkshelf, version: "v7.2.2"
 # 1.1.1i+ builds on m1 mac
 override :openssl, version: "1.1.1l"
 
+# xproto 7.0.31 became the default version in omnibus-software but it failed to build on
+# multiple non-x86_64 systems. (e.g. arm64, ppc64)
+override :xproto, version: "7.0.25"
+
 if solaris?
   # More recent versions of git build on Solaris but "git name-rev" doesn't work properly which fails Chef Infra tests
   override :git, version: "2.24.1"

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -49,6 +49,9 @@ override :openssl, version: "1.1.1l"
 # multiple non-x86_64 systems. (e.g. arm64, ppc64)
 override :xproto, version: "7.0.25"
 
+# curl 7.81.0 became the default version in omnibus-software but it failed to build on macos x86_64
+override :curl, version: "7.80.0"
+
 if solaris?
   # More recent versions of git build on Solaris but "git name-rev" doesn't work properly which fails Chef Infra tests
   override :git, version: "2.24.1"


### PR DESCRIPTION
Pin xproto to 7.0.25. xproto 7.0.31 became the default version in omnibus-software but it failed to build on multiple non-x86_64 systems. (e.g. arm64, ppc64)

Pin curl to 7.80.0. curl 7.81.0 became the default version in omnibus-software but it failed to build on macos x86_64.