### PR TITLE
IPACK-204 Prepare for new omnibus-toolchain build

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -39,6 +39,10 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
+  el-9-aarch64:
+    - el-9-aarch64
+  el-9-x86_64:
+    - el-9-x86_64
   freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64

--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -70,8 +70,6 @@ builder-to-testers-map:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
-  windows-2012r2-i386:
-    - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -39,6 +39,10 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
+  el-9-aarch64:
+    - el-9-aarch64
+  el-9-x86_64:
+    - el-9-x86_64
   freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -70,8 +70,6 @@ builder-to-testers-map:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
-  windows-2012r2-i386:
-    - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -39,6 +39,10 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
+  el-9-aarch64:
+    - el-9-aarch64
+  el-9-x86_64:
+    - el-9-x86_64
   freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -70,8 +70,6 @@ builder-to-testers-map:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
-  windows-2012r2-i386:
-    - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -39,6 +39,10 @@ builder-to-testers-map:
     - el-8-aarch64
   el-8-x86_64:
     - el-8-x86_64
+  el-9-aarch64:
+    - el-9-aarch64
+  el-9-x86_64:
+    - el-9-x86_64
   freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -70,8 +70,6 @@ builder-to-testers-map:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64
-  windows-2012r2-i386:
-    - windows-2012r2-i386
   windows-2012r2-x86_64:
     - windows-2012-x86_64
     - windows-2012r2-x86_64

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -45,7 +45,7 @@ end
 override :ruby, version: "2.7.5"
 
 # riding berkshelf master is hard when you're at the edge of versions
-override :berkshelf, version: "v7.2.2"
+override :berkshelf, version: "v8.0.1"
 
 # 1.1.1i+ builds on m1 mac
 override :openssl, version: "1.1.1m"

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -55,9 +55,6 @@ override :openssl, version: "1.1.1m"
 # multiple non-x86_64 systems. (e.g. arm64, ppc64)
 override :xproto, version: "7.0.25"
 
-# curl 7.81.0 became the default version in omnibus-software but it failed to build on macos x86_64
-override :curl, version: "7.80.0"
-
 if solaris?
   # More recent versions of git build on Solaris but "git name-rev" doesn't work properly which fails Chef Infra tests
   override :git, version: "2.24.1"

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -43,7 +43,6 @@ else
 end
 
 override :ruby, version: "2.7.5"
-override :gtar, version: "1.32"
 
 # riding berkshelf master is hard when you're at the edge of versions
 override :berkshelf, version: "v7.2.2"

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -64,9 +64,6 @@ if solaris?
 
   # Solaris fails compile on libtool version 2.4.2 and 2.4.6
   override :libtool, version: "2.4"
-
-  # Newer versions of ncurses cause libedit build failures on Solaris
-  override :ncurses, version: "5.9"
 end
 
 

--- a/config/software/cmake.rb
+++ b/config/software/cmake.rb
@@ -15,23 +15,23 @@
 #
 
 name "cmake"
-default_version "3.12.2"
+default_version "3.23.1"
 
 dependency "cacerts"
 
 license "BSD-3-Clause"
 skip_transitive_dependency_licensing true
-version("3.12.2") { source sha256: "7212130c7798c994fe22ed5cbf5fa454cdaea636b07d1571c015606929f92c9a" }
+version("3.23.1") { source sha256: "33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3" }
 minor_version = version.split(".")[0..1].join(".")
 
 if windows?
   if windows_arch_i386?
-    source url: "https://cmake.org/files/v#{minor_version}/cmake-#{version}-win32-x86.zip", sha256: "fde814282b798a8064aab8c44ddf2f7a25e1139b5a2b3a255adedacfca5706cd"
-    relative_path "cmake-#{version}-win32-x86"
+    source url: "https://cmake.org/files/v#{minor_version}/cmake-#{version}-windows-i386.zip", sha256: "5bb01d27dc665aac5ddbdb24eebfb2146601e150884b2b1540d39ceb61875f3f"
+    relative_path "cmake-#{version}-windows-i386"
     license_file "doc/cmake/Copyright.txt"
   else
-    source url: "https://cmake.org/files/v#{minor_version}/cmake-#{version}-win64-x64.zip", sha256: "25c8dbe3e81095463b0d6ccefd836275791299502e3ed5eccf695e118a6d031b"
-    relative_path "cmake-#{version}-win64-x64"
+    source url: "https://cmake.org/files/v#{minor_version}/cmake-#{version}-windows-x86_64.zip", sha256: "9b509cc4eb7191dc128cfa3f2170036f9cbc7d9d5f93ff7fafc5b2d77b3b40dc"
+    relative_path "cmake-#{version}-windows-x86_64"
     license_file "doc/cmake/Copyright.txt"
   end
 else

--- a/omnibus-test.ps1
+++ b/omnibus-test.ps1
@@ -4,19 +4,16 @@ $ErrorActionPreference = "Stop"
 $Env:PATH = "C:\opscode\$Env:PRODUCT\embedded\bin;$Env:PATH"
 
 $embedded_bin_dir = "C:\opscode\$Env:PRODUCT\embedded\bin"
-$project_bin_dir = "C:\opscode\$Env:PRODUCT\bin"
 
 # Exercise various packaged tools to validate binstub shebangs
 & $embedded_bin_dir\ruby --version
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
+If ($lastexitcode -ne 0) { Throw $lastexitcode }
 
-& $embedded_bin_dir\bundle.cmd --version
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
+& $embedded_bin_dir\bundle --version
+If ($lastexitcode -ne 0) { Throw $lastexitcode }
 
 & $embedded_bin_dir\git --version
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
+If ($lastexitcode -ne 0) { Throw $lastexitcode }
 
-& $project_bin_dir\load-omnibus-toolchain.ps1
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
-
-exit $LASTEXITCODE
+& $embedded_bin_dir\ruby -r openssl -e "puts 'Ruby can load OpenSSL'"
+If ($lastexitcode -ne 0) { Throw $lastexitcode }

--- a/omnibus-test.sh
+++ b/omnibus-test.sh
@@ -33,6 +33,8 @@ BINDIR="$INSTALL_DIR/bin/"
 "$BINDIR/ruby" --version
 "$BINDIR/tar" --version
 
+"$BINDIR/ruby" -r openssl -e 'puts "Ruby can load OpenSSL"'
+
 # Test that bash works
 # shellcheck disable=SC2016
 "$BINDIR/bash" -c 'echo $(uptime)'


### PR DESCRIPTION
Stop building on windows-2012r2-i386

We no longer need a 32 bit omnibus-toolchain package because the AMI used for windows-2012r2-i386 is the same used for the windows-2012r2-x86_64 platform.

Fix omnibus-test.ps1 and omnibus-test.sh

Unpin ncurses for solaris

Unpin curl

Unpin gtar

Update cmake

Bump berkshelf to 8.0.1

Add RHEL 9 to build matrices