### PR TITLE
IPACK-204 use ruby 3.1, openssl 3 and UCRT64

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -3,6 +3,7 @@ project-name: omnibus-toolchain
 config: omnibus.rb
 test-path: omnibus-test.sh
 test-path-windows: omnibus-test.ps1
+windows-64-msystem: UCRT64
 builder-to-testers-map:
   # aix-7.1-powerpc:
   #   - aix-7.1-powerpc

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -3,6 +3,7 @@ project-name: angry-omnibus-toolchain
 config: omnibus.rb
 test-path: omnibus-test.sh
 test-path-windows: omnibus-test.ps1
+windows-64-msystem: UCRT64
 builder-to-testers-map:
   # aix-7.1-powerpc:
   #   - aix-7.1-powerpc

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -3,6 +3,7 @@ project-name: angry-omnibus-toolchain
 config: omnibus.rb
 test-path: omnibus-test.sh
 test-path-windows: omnibus-test.ps1
+windows-64-msystem: UCRT64
 builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -3,6 +3,7 @@ project-name: omnibus-toolchain
 config: omnibus.rb
 test-path: omnibus-test.sh
 test-path-windows: omnibus-test.ps1
+windows-64-msystem: UCRT64
 builder-to-testers-map:
   aix-7.1-powerpc:
     - aix-7.1-powerpc

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -42,13 +42,14 @@ else
   install_dir "#{default_root}/#{name}"
 end
 
-override :ruby, version: "2.7.5"
-
 # riding berkshelf master is hard when you're at the edge of versions
 override :berkshelf, version: "v8.0.1"
 
-# 1.1.1i+ builds on m1 mac
-override :openssl, version: "1.1.1m"
+override :openssl, version: (aix? || windows?) ? "1.1.1m" : "3.0.1"
+
+# it is important to set the default ruby version here. some software definitions such as
+# nokogiri determine whether to compile or not on windows
+override :ruby, version: aix? ? "3.0.3" : "3.1.2"
 
 # xproto 7.0.31 became the default version in omnibus-software but it failed to build on
 # multiple non-x86_64 systems. (e.g. arm64, ppc64)


### PR DESCRIPTION
Build ruby 3.1 and openssl 3

Use UCRT64 toolchain for 64 bit Windows builds
