### PR TITLE
Lint ruby files using chefstyle on pull-requests

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -100,3 +100,7 @@ subscriptions:
     actions:
       - built_in:rollover_changelog
       - built_in:notify_chefio_slack_channels
+pipelines:
+  - verify:
+      description: Pull Request validation tests
+      public: true

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,0 +1,18 @@
+---
+expeditor:
+  defaults:
+    buildkite:
+      retry:
+        automatic:
+          limit: 1
+      timeout_in_minutes: 30
+
+steps:
+- label: run-lint-ruby-3.1
+  command:
+    - bundle install --jobs=3 --retry=3
+    - rake chefstyle
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1-buster

--- a/config/projects/angry-omnibus-toolchain.rb
+++ b/config/projects/angry-omnibus-toolchain.rb
@@ -19,9 +19,10 @@
 # the omnibus-toolchain build and test machines. As such this project
 # definition is just a thin wrapper around `config/project/omnibus-toolchain.rb`.
 #
+# rubocop:disable Lint/UselessAssignment
 current_file = __FILE__
-toolchain_project_contents = IO.read(File.expand_path("../omnibus-toolchain.rb", __FILE__))
-self.instance_eval toolchain_project_contents
+toolchain_project_contents = IO.read(File.expand_path("omnibus-toolchain.rb", __dir__))
+instance_eval toolchain_project_contents
 
 name "angry-omnibus-toolchain"
 friendly_name "Angry Omnibus Toolchain"
@@ -41,3 +42,4 @@ resources_path "#{resources_path}/../omnibus-toolchain"
 
 msi_upgrade_code = "6662C48D-761B-4E1D-91B8-9F17B9B36428"
 project_location_dir = "angry-omnibus-toolchain"
+# rubocop:enable Lint/UselessAssignment

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -68,7 +68,6 @@ if solaris?
   override :libtool, version: "2.4"
 end
 
-
 # creates required build directories
 dependency "preparation"
 

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -19,7 +19,6 @@ default_version "1.0.0"
 
 license :project_license
 
-
 # gnu utilities
 if windows?
   dependency "cmake"


### PR DESCRIPTION
## Description
This PR adds a verify pipeline that lints ruby files on pull-request commits

## Related Issue
BS-83 (JIRA)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
