### PR TITLE
Fix Solaris Build Issue

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -73,6 +73,9 @@ if solaris?
 
   # Solaris fails compile on libtool version 2.4.2 and 2.4.6
   override :libtool, version: "2.4"
+
+  # Solaris fails to compile curl version >7.81.0 with nghttp2 unreferenced symbol
+  override :curl, version: "7.81.0"
 end
 
 # creates required build directories


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Curl Build failed on solaris with nghttp2 unreferenced symbols.
This issue occurs for the curl version > 7.81.0
Pinned curl version to 7.81.0  for solrais

Error :

nghttp2_pack_settings_payload       ../lib/.libs/libcurl.so
  | nghttp2_session_send                ../lib/.libs/libcurl.so
  | ld: fatal: symbol referencing errors
  | collect2: error: ld returned 1 exit status
  | gmake[2]: *** [Makefile:991: curl] Error 1


## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
