### PR TITLE
unpin libxlm & libxslt

### DIFF
--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -36,8 +36,8 @@ if windows?
   # libxslt 1.1.35 does not build successfully with libxml2 2.9.13 on Windows so we will pin
   # windows builds to libxslt 1.1.34 and libxml2 2.9.10 for now and followup later with the
   # work to fix that issue in IPACK-145.
-  override "libxml2", version: "2.9.10"
-  override "libxslt", version: "1.1.34"
+  #override "libxml2", version: "2.9.10"
+  #override "libxslt", version: "1.1.34"
 else
   install_dir "#{default_root}/#{name}"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Regarding -  IPACK-145
The builds are failing while building libxslt but it’s  something about the libxml2 build is causing the problem.
unpin the libxslt & libxml .
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
