### PR TITLE
remove mac10.15 from pipeline and make mac 11 as builder

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -46,11 +46,9 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  freebsd-12-amd64:
-    - freebsd-12-amd64
+  freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-10.15-x86_64:
-    - mac_os_x-10.15-x86_64
+  mac_os_x-11-x86_64:
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64
   mac_os_x-11-arm64:

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -46,11 +46,9 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  freebsd-12-amd64:
-    - freebsd-12-amd64
+  freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-10.15-x86_64:
-    - mac_os_x-10.15-x86_64
+  mac_os_x-11-x86_64:
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64
   mac_os_x-11-arm64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -46,11 +46,9 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  freebsd-12-amd64:
-    - freebsd-12-amd64
+  freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-10.15-x86_64:
-    - mac_os_x-10.15-x86_64
+  mac_os_x-11-x86_64:
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64
   mac_os_x-11-arm64:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,26 +22,26 @@ pipelines:
   - omnibus/release:
       env:
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 985c89882458519dbad2f45e77e6a492c73d18ed
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 985c89882458519dbad2f45e77e6a492c73d18ed
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-release:
       env:
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 985c89882458519dbad2f45e77e6a492c73d18ed
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc:
       definition: .expeditor/angry-release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 985c89882458519dbad2f45e77e6a492c73d18ed
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   # the canary pipelines are used for testing by our *-buildkite-pipelines repos
   - omnibus/adhoc-canary:
@@ -50,7 +50,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 985c89882458519dbad2f45e77e6a492c73d18ed
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc-canary:
       canary: true
@@ -58,7 +58,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 985c89882458519dbad2f45e77e6a492c73d18ed
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
         - OMNIBUS_USE_INTERNAL_SOURCES: true
 
 github:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -46,11 +46,9 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  freebsd-12-amd64:
-    - freebsd-12-amd64
+  freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-10.15-x86_64:
-    - mac_os_x-10.15-x86_64
+  mac_os_x-11-x86_64:
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64
   mac_os_x-11-arm64:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: d357d5cf84dce2b99b28093c4a5c32f2f96b4787
+  revision: 99965d0f928c0af9e218dd5e2251f2cc53f47a20
   branch: main
   specs:
-    omnibus-software (23.11.307)
+    omnibus-software (24.4.318)
       omnibus (>= 9.0.0)
 
 GIT

--- a/config/software/gtar.rb
+++ b/config/software/gtar.rb
@@ -15,8 +15,9 @@
 #
 
 name "gtar"
-default_version "1.32"
+default_version "1.34"
 
+version("1.34") { source sha256: "03d908cf5768cfe6b7ad588c921c6ed21acabfb2b79b788d1330453507647aed" }
 version("1.32") { source sha256: "b59549594d91d84ee00c99cf2541a3330fed3a42c440503326dab767f2fbb96c" }
 
 license "GPL-3.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
this will remove mac 10.15 from pipelines as this is outdated and making  mac 11 as builder and also freebsd 12 removal and making 13 as builder

And also will pick the latest OMNIBUS_BUILDKITE_PLUGIN_VERSION where new IBM hosts are pushed

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
