### PR TITLE
remove el6 and update buildkite-plugin version

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -23,8 +23,6 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -23,8 +23,6 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -23,8 +23,6 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,26 +22,26 @@ pipelines:
   - omnibus/release:
       env:
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-release:
       env:
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc:
       definition: .expeditor/angry-release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   # the canary pipelines are used for testing by our *-buildkite-pipelines repos
   - omnibus/adhoc-canary:
@@ -50,7 +50,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc-canary:
       canary: true
@@ -58,7 +58,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
         - OMNIBUS_USE_INTERNAL_SOURCES: true
 
 github:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,26 +22,26 @@ pipelines:
   - omnibus/release:
       env:
         - IGNORE_CACHE: true
-        #- OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        #- OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-release:
       env:
         - IGNORE_CACHE: true
-        #- OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc:
       definition: .expeditor/angry-release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        #- OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   # the canary pipelines are used for testing by our *-buildkite-pipelines repos
   - omnibus/adhoc-canary:
@@ -50,7 +50,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        #- OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc-canary:
       canary: true
@@ -58,7 +58,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        #- OMNIBUS_BUILDKITE_PLUGIN_VERSION: 00bcaee3b5474d71e300db2c31c4400bc020f3cd
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: a176fa5dacb85928a83c3229a134a7c9599e7f8a
         - OMNIBUS_USE_INTERNAL_SOURCES: true
 
 github:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -23,8 +23,6 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -103,10 +103,10 @@ package :msi do
   upgrade_code msi_upgrade_code
   wix_candle_extension "WixUtilExtension"
   wix_light_extension "WixUtilExtension"
-  signing_identity "769E6AF679126F184850AAC7C5C823A80DB3ADAA", machine_store: false, keypair_alias: "key_495941360"
+  signing_identity "7D16AE73AB249D473362E9332D029089DBBB89B2", machine_store: false, keypair_alias: "key_875762014"
   parameters ProjectLocationDir: project_location_dir
 end
 
 package :appx do
-  signing_identity "769E6AF679126F184850AAC7C5C823A80DB3ADAA", machine_store: false, keypair_alias: "key_495941360"
+  signing_identity "7D16AE73AB249D473362E9332D029089DBBB89B2", machine_store: false, keypair_alias: "key_875762014"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Picking the latest digi cert token for windows platforms and also removal of el-6 from release pipeline since its EOL
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
