### PR TITLE
remove mac 11 as its EOL and update 12 as builder omniubs toolchain/muthuja

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -46,11 +46,9 @@ builder-to-testers-map:
     - el-9-x86_64
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   rocky-8-x86_64:
     - rocky-8-x86_64

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -46,11 +46,10 @@ builder-to-testers-map:
     - el-9-x86_64
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
+    - mac_os_x-12-arm64
   rocky-8-x86_64:
     - rocky-8-x86_64
   rocky-8-aarch64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -46,11 +46,9 @@ builder-to-testers-map:
     - el-9-x86_64
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   rocky-8-x86_64:
     - rocky-8-x86_64

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,26 +22,26 @@ pipelines:
   - omnibus/release:
       env:
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 8291538da3f3ab8f037ff7a56d77e1ab02c4bbf9
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/adhoc:
       definition: .expeditor/release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 8291538da3f3ab8f037ff7a56d77e1ab02c4bbf9
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-release:
       env:
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 8291538da3f3ab8f037ff7a56d77e1ab02c4bbf9
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc:
       definition: .expeditor/angry-release.omnibus.yml
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 8291538da3f3ab8f037ff7a56d77e1ab02c4bbf9
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   # the canary pipelines are used for testing by our *-buildkite-pipelines repos
   - omnibus/adhoc-canary:
@@ -50,7 +50,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 8291538da3f3ab8f037ff7a56d77e1ab02c4bbf9
         - OMNIBUS_USE_INTERNAL_SOURCES: true
   - omnibus/angry-adhoc-canary:
       canary: true
@@ -58,7 +58,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: e5637ca1ed34a227eba86ae30761010f308b2d1b
+        - OMNIBUS_BUILDKITE_PLUGIN_VERSION: 8291538da3f3ab8f037ff7a56d77e1ab02c4bbf9
         - OMNIBUS_USE_INTERNAL_SOURCES: true
 
 github:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -46,11 +46,9 @@ builder-to-testers-map:
     - el-9-x86_64
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   rocky-8-x86_64:
     - rocky-8-x86_64

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: dd171125b10e9a457090cc20165ee4ecf2e0d51d
+  revision: 9de7c78bdcd58c021f3cddeea7ac573a7183fffd
   branch: main
   specs:
-    omnibus-software (24.6.323)
+    omnibus-software (24.6.324)
       omnibus (>= 9.0.0)
 
 GIT

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -41,7 +41,7 @@ dependency "ruby"
 
 # Projects such as Chef Server, Supermarket, Chef Manage and Chef Backend use berkshelf for the build time installation of gems.
 # Moving it to toolchain avoids installing a ton of deps into our packages.
-if linux? || macos?
+if linux?
   dependency "berkshelf" unless i386? || arm?
 end
 

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -41,6 +41,8 @@ dependency "ruby"
 
 # Projects such as Chef Server, Supermarket, Chef Manage and Chef Backend use berkshelf for the build time installation of gems.
 # Moving it to toolchain avoids installing a ton of deps into our packages.
+# chef-server and their components never built on mac , so we can stop building berkshelf on mac 
+# if its requires in future for mac can add it back here and test
 if linux?
   dependency "berkshelf" unless i386? || arm?
 end

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -41,7 +41,7 @@ dependency "ruby"
 
 # Projects such as Chef Server, Supermarket, Chef Manage and Chef Backend use berkshelf for the build time installation of gems.
 # Moving it to toolchain avoids installing a ton of deps into our packages.
-# chef-server and their components never built on mac , so we can stop building berkshelf on mac 
+# chef-server and their components never built on mac , so we can stop building berkshelf on mac
 # if its requires in future for mac can add it back here and test
 if linux?
   dependency "berkshelf" unless i386? || arm?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

1. Removal of mac 11 from pipeline as its EOL and updating 12 as builder.
2. Picked latest sha from omnibus-buildkite-plugin to get those changes.
3. Updated latest version of omnibus-software and sha.
4. Stop building berkshelf for mac as its not required for mac platforms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
