### PR TITLE
adding darwin-20 and freebsd-13 x86_64 to the platform list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,7 +242,9 @@ PLATFORMS
   s390x-linux
   sparc-solaris-2.11
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-freebsd-12
+  x86_64-freebsd-13
   x86_64-linux
   x86_64-solaris-2.11
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<img width="1716" alt="Screenshot 2025-03-20 at 7 39 25 PM" src="https://github.com/user-attachments/assets/1bb340f7-3e1f-4795-bce8-39e29cdda41c" />
<img width="1716" alt="Screenshot 2025-03-20 at 7 39 41 PM" src="https://github.com/user-attachments/assets/892e377a-f565-4cd9-8c2e-ffb2a5709ee6" />

this change is fix for the below errors 

> Running `bundle install` with bundler 2.3.26
--
  | Bundler::ProductionError: Your bundle only supports platforms ["aarch64-linux", "arm64-darwin-20", "powerpc-aix-7", "powerpc64-linux", "powerpc64le-linux", "s390x-linux", "sparc-solaris-2.11", "x86_64-darwin-19", "x86_64-freebsd-12", "x86_64-linux", "x86_64-solaris-2.11"] but your local platform is x86_64-freebsd-13. Add the current platform to the lockfile with
  | `bundle lock --add-platform x86_64-freebsd-13` and try again.

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
