### PR TITLE
enalbing 2025, disabling 2012, 2012r2

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -85,12 +85,13 @@ builder-to-testers-map:
     - ubuntu-24.04-x86_64
   ubuntu-24.04-aarch64:
     - ubuntu-24.04-aarch64
-  windows-2012r2-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
+  windows-2019-x86_64:
+    # - windows-2012-x86_64
+    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64
+    - windows-2025-x86_64
   #  - windows-8-x86_64
     - windows-10-x86_64
     - windows-11-x86_64

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -86,12 +86,13 @@ builder-to-testers-map:
     - ubuntu-24.04-x86_64
   ubuntu-24.04-aarch64:
     - ubuntu-24.04-aarch64
-  windows-2012r2-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
+  windows-2019-x86_64:
+    # - windows-2012-x86_64
+    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64
+    - windows-2025-x86_64
   #  - windows-8-x86_64
     - windows-10-x86_64
     - windows-11-x86_64

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -83,12 +83,13 @@ builder-to-testers-map:
     - ubuntu-24.04-x86_64
   ubuntu-24.04-aarch64:
     - ubuntu-24.04-aarch64
-  windows-2012r2-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
+  windows-2019-x86_64:
+    # - windows-2012-x86_64
+    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64
-  # - windows-8-x86_64
+    - windows-2025-x86_64
+  #  - windows-8-x86_64
     - windows-10-x86_64
     - windows-11-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -85,9 +85,9 @@ builder-to-testers-map:
     - ubuntu-24.04-x86_64
   ubuntu-24.04-aarch64:
     - ubuntu-24.04-aarch64
-  windows-2012r2-x86_64:
-    - windows-2012-x86_64
-    - windows-2012r2-x86_64
+  windows-2019-x86_64:
+    # - windows-2012-x86_64
+    # - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

removing 2012, 2012r2 and enabling 2025. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
