### PR TITLE
add rhel-10 support to omnibus-toolchain

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -44,6 +44,10 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
+  el-10-x86_64:
+    - el-10-x86_64
+  el-10-aarch64:
+    - el-10-aarch64
   freebsd-13-amd64:
     - freebsd-13-amd64
   mac_os_x-12-x86_64:

--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -50,10 +50,7 @@ builder-to-testers-map:
     - el-10-aarch64
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-12-x86_64:
-    - mac_os_x-12-x86_64
-  mac_os_x-12-arm64:
-    - mac_os_x-12-arm64
+  mac_os_x-13-arm64:
     - mac_os_x-13-arm64
     - mac_os_x-14-arm64
   rocky-8-x86_64:

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -44,6 +44,10 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
+  el-10-x86_64:
+    - el-10-x86_64
+  el-10-aarch64:
+    - el-10-aarch64    
   freebsd-13-amd64:
     - freebsd-13-amd64
   mac_os_x-12-x86_64:

--- a/.expeditor/angry-adhoc-canary.omnibus.yml
+++ b/.expeditor/angry-adhoc-canary.omnibus.yml
@@ -50,10 +50,7 @@ builder-to-testers-map:
     - el-10-aarch64    
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-12-x86_64:
-    - mac_os_x-12-x86_64
-  mac_os_x-12-arm64:
-    - mac_os_x-12-arm64
+  mac_os_x-13-arm64:
     - mac_os_x-13-arm64
     - mac_os_x-14-arm64
   rocky-8-x86_64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -44,6 +44,10 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
+  el-10-x86_64:
+    - el-10-x86_64
+  el-10-aarch64:
+    - el-10-aarch64    
   freebsd-13-amd64:
     - freebsd-13-amd64
   mac_os_x-12-x86_64:

--- a/.expeditor/angry-release.omnibus.yml
+++ b/.expeditor/angry-release.omnibus.yml
@@ -50,10 +50,9 @@ builder-to-testers-map:
     - el-10-aarch64    
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-12-x86_64:
-    - mac_os_x-12-x86_64
-  mac_os_x-12-arm64:
-    - mac_os_x-12-arm64
+  mac_os_x-13-arm64:
+    - mac_os_x-13-arm64
+    - mac_os_x-14-arm64
   rocky-8-x86_64:
     - rocky-8-x86_64
   rocky-8-aarch64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -44,6 +44,10 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
+  el-10-x86_64:
+    - el-10-x86_64
+  el-10-aarch64:
+    - el-10-aarch64    
   freebsd-13-amd64:
     - freebsd-13-amd64
   mac_os_x-12-x86_64:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -50,10 +50,7 @@ builder-to-testers-map:
     - el-10-aarch64    
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-12-x86_64:
-    - mac_os_x-12-x86_64
-  mac_os_x-12-arm64:
-    - mac_os_x-12-arm64
+  mac_os_x-13-arm64:
     - mac_os_x-13-arm64
     - mac_os_x-14-arm64
   rocky-8-x86_64:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "omnibus", github: ENV.fetch("OMNIBUS_GITHUB_REPO", "chef/omnibus"), branch: ENV.fetch("OMNIBUS_GITHUB_BRANCH", "CHEF-27997-add-el-9-to-packagers-rpm-file-omnibus-repo/muthuja")
+gem "omnibus", github: ENV.fetch("OMNIBUS_GITHUB_REPO", "chef/omnibus"), branch: ENV.fetch("OMNIBUS_GITHUB_BRANCH", "main")
 gem "omnibus-software", github: ENV.fetch("OMNIBUS_SOFTWARE_GITHUB_REPO", "chef/omnibus-software"), branch: ENV.fetch("OMNIBUS_SOFTWARE_GITHUB_BRANCH", "main")
 gem 'artifactory'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "omnibus", github: ENV.fetch("OMNIBUS_GITHUB_REPO", "chef/omnibus"), branch: ENV.fetch("OMNIBUS_GITHUB_BRANCH", "main")
+gem "omnibus", github: ENV.fetch("OMNIBUS_GITHUB_REPO", "chef/omnibus"), branch: ENV.fetch("OMNIBUS_GITHUB_BRANCH", "CHEF-27997-add-el-9-to-packagers-rpm-file-omnibus-repo/muthuja")
 gem "omnibus-software", github: ENV.fetch("OMNIBUS_SOFTWARE_GITHUB_REPO", "chef/omnibus-software"), branch: ENV.fetch("OMNIBUS_SOFTWARE_GITHUB_BRANCH", "main")
 gem 'artifactory'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 9de7c78bdcd58c021f3cddeea7ac573a7183fffd
+  revision: ead37053551477d0dd52fd8a411286e7f649c338
   branch: main
   specs:
-    omnibus-software (24.6.324)
+    omnibus-software (25.11.354)
       omnibus (>= 9.0.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: c885825f1886cfe3d7a2e139e40de1f5b4b91374
+  revision: b9f4c8f7ae7d01faebf6ee9188abcf207a4e823d
   branch: main
   specs:
-    omnibus (9.1.0)
+    omnibus (9.1.5)
       aws-sdk-s3 (~> 1.116.0)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: ead37053551477d0dd52fd8a411286e7f649c338
+  revision: d6fce7b6c5e6a9ba1f3a21eef2b2be8ee778391f
   branch: main
   specs:
-    omnibus-software (25.11.354)
+    omnibus-software (25.12.358)
       omnibus (>= 9.0.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: b9f4c8f7ae7d01faebf6ee9188abcf207a4e823d
+  revision: e55f9bc189d721ddbe34d6e5cc188147c328936b
   branch: main
   specs:
-    omnibus (9.1.5)
+    omnibus (9.1.6)
       aws-sdk-s3 (~> 1.116.0)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)

--- a/config/projects/omnibus-toolchain.rb
+++ b/config/projects/omnibus-toolchain.rb
@@ -103,10 +103,10 @@ package :msi do
   upgrade_code msi_upgrade_code
   wix_candle_extension "WixUtilExtension"
   wix_light_extension "WixUtilExtension"
-  signing_identity "7D16AE73AB249D473362E9332D029089DBBB89B2", machine_store: false, keypair_alias: "key_875762014"
+  signing_identity "33A82DC08CA7C6B370FFD0C958D9EE30187DE9E4", machine_store: false, keypair_alias: "key_1340572417"
   parameters ProjectLocationDir: project_location_dir
 end
 
 package :appx do
-  signing_identity "7D16AE73AB249D473362E9332D029089DBBB89B2", machine_store: false, keypair_alias: "key_875762014"
+  signing_identity "33A82DC08CA7C6B370FFD0C958D9EE30187DE9E4", machine_store: false, keypair_alias: "key_1340572417"
 end

--- a/config/software/archive-tar-minitar.rb
+++ b/config/software/archive-tar-minitar.rb
@@ -1,0 +1,11 @@
+name "archive-tar-minitar"
+default_version "0.12"
+
+license "MIT"
+
+dependency "ruby"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  gem "install archive-tar-minitar -v #{version} --no-document", env: env
+end

--- a/config/software/berkshelf-no-depselector.rb
+++ b/config/software/berkshelf-no-depselector.rb
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2016 Chef Software, Inc.
+# Copyright 2014-2018 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,33 +17,19 @@
 # expeditor/ignore: deprecated 2021-04
 
 name "berkshelf-no-depselector"
-default_version "main"
 
 license "Apache-2.0"
-license_file "LICENSE"
+license_file "https://raw.githubusercontent.com/berkshelf/berkshelf/main/LICENSE"
+# berkshelf does not have any dependencies. We only install it from
+# rubygems here.
+skip_transitive_dependency_licensing true
 
-source git: "https://github.com/berkshelf/berkshelf.git"
-
-relative_path "berkshelf"
-
-dependency "ruby"
-
-unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
-  dependency "libarchive"
-end
-
+dependency "archive-tar-minitar"
 dependency "nokogiri"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "config set --local without guard changelog development test", env: env
-  bundle "install --jobs #{workers}", env: env
-
-  bundle "exec thor gem:build", env: env
-
-  gem "install pkg/berkshelf-*.gem" \
-      " --no-document", env: env
-  # This line ensures the missing runtime dep is present
-  gem "install archive-tar-minitar --no-document", env: env    
+  gem "install berkshelf" \
+      "  --no-document", env: env
 end

--- a/config/software/berkshelf-no-depselector.rb
+++ b/config/software/berkshelf-no-depselector.rb
@@ -1,0 +1,49 @@
+
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# expeditor/ignore: deprecated 2021-04
+
+name "berkshelf-no-depselector"
+default_version "main"
+
+license "Apache-2.0"
+license_file "LICENSE"
+
+source git: "https://github.com/berkshelf/berkshelf.git"
+
+relative_path "berkshelf"
+
+dependency "ruby"
+
+unless windows? && (project.overrides[:ruby].nil? || project.overrides[:ruby][:version] == "ruby-windows")
+  dependency "libarchive"
+end
+
+dependency "nokogiri"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "config set --local without guard changelog development test", env: env
+  bundle "install --jobs #{workers}", env: env
+
+  bundle "exec thor gem:build", env: env
+
+  gem "install pkg/berkshelf-*.gem" \
+      " --no-document", env: env
+  # This line ensures the missing runtime dep is present
+  gem "install archive-tar-minitar --no-document", env: env    
+end

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -43,8 +43,16 @@ dependency "ruby"
 # Moving it to toolchain avoids installing a ton of deps into our packages.
 # chef-server and their components never built on mac , so we can stop building berkshelf on mac
 # if its requires in future for mac can add it back here and test
+# for rhel-10x86_64 and ubuntu-24.04 x86_64 berkshelf build is failing due to dep-selector-libgecod error
+# so we can skip berkshelf and we can use berkshelf-no-depselector software which will skip dep-selector-libgecod gem installation
+# if in future its required can add dep-selector-libgecod fix for rhel-10 and ubuntu-24.04 and can build berkshelf gem
 if linux?
-  dependency "berkshelf" unless i386? || arm?
+  # build berkshelf-no-depselector for rhel-10x86_64 and ubuntu-24.04-x86_64
+  if (rhel? && ohai["platform_version"].to_i == 10 && x86_64?) || (ubuntu? && ohai["platform_version"] == "24.04" && x86_64?)
+    dependency "berkshelf-no-depselector"
+  else
+    dependency "berkshelf" unless i386? || arm?
+  end
 end
 
 dependency "nokogiri"

--- a/config/software/omnibus-toolchain.rb
+++ b/config/software/omnibus-toolchain.rb
@@ -48,7 +48,7 @@ dependency "ruby"
 # if in future its required can add dep-selector-libgecod fix for rhel-10 and ubuntu-24.04 and can build berkshelf gem
 if linux?
   # build berkshelf-no-depselector for rhel-10x86_64 and ubuntu-24.04-x86_64
-  if (rhel? && ohai["platform_version"].to_i == 10 && x86_64?) || (ubuntu? && ohai["platform_version"] == "24.04" && x86_64?)
+  if (rhel? && ohai["platform_version"].to_i == 10 && ohai["kernel"]["machine"] == "x86_64") || (ubuntu? && ohai["platform_version"] == "24.04" && ohai["kernel"]["machine"] == "x86_64")
     dependency "berkshelf-no-depselector"
   else
     dependency "berkshelf" unless i386? || arm?

--- a/omnibus.rb
+++ b/omnibus.rb
@@ -41,7 +41,9 @@ windows_arch   env_omnibus_windows_arch
 use_s3_caching true
 s3_access_key  ENV['AWS_ACCESS_KEY_ID']
 s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
-s3_bucket      'opscode-omnibus-cache'
+s3_bucket      'opscode-omnibus-cache-private'
+s3_acl         'private'
+s3_region      'us-west-2'
 
 # Customize compiler bits
 # ------------------------------


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
**Platform Support Updates:**

* Added support for `el-10-x86_64` and `el-10-aarch64` platforms and updated macOS support to use `mac_os_x-13-arm64` and `mac_os_x-14-arm64` 

**Build and Dependency Management:**

* Introduced a new `berkshelf-no-depselector` software definition and its dependency `archive-tar-minitar`, and configured `omnibus-toolchain.rb` to use this alternative on RHEL 10 x86_64 and Ubuntu 24.04 x86_64 to avoid build failures caused by `dep-selector-libgecod` [[1]](diffhunk://#diff-8e18bce6ac8e947a75abbf60851e6c930d06bfd62be82395c0f2535c92299223R1-R35) [[2]](diffhunk://#diff-c0621a802a08abc16f73dcf3befc568aa9a687ba1a1cc8735400401cfcf03bdaR1-R11) [[3]](diffhunk://#diff-2080ead84470e2b7da01a6e7fa7888d49b5944bf67859a3527bf6f52aca29048R46-R56).

**Signing and Security:**

* Updated the Windows and AppX signing identities in `config/projects/omnibus-toolchain.rb` to use new certificate and keypair values.

**S3 Caching Configuration:**

* Changed the S3 bucket for omnibus cache to `opscode-omnibus-cache-private`, set the ACL to `private`, and specified the region as `us-west-2` in `omnibus.rb`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
This pull request introduces several changes to improve platform support, update build and signing configurations, and address build issues for specific environments. The most notable updates are the addition of support for RHEL 10 and newer macOS platforms, the introduction of a workaround for berkshelf build failures on certain platforms, and updates to signing identities and S3 caching configuration.

